### PR TITLE
fixed shaded package name

### DIFF
--- a/google-cloud-contrib/google-cloud-nio/pom.xml
+++ b/google-cloud-contrib/google-cloud-nio/pom.xml
@@ -103,7 +103,7 @@
           <relocations>
             <relocation>
               <pattern>com</pattern>
-              <shadedPattern>shaded.cloud-nio.com</shadedPattern>
+              <shadedPattern>shaded.cloud_nio.com</shadedPattern>
               <excludes>
                 <exclude>com.google.cloud.**</exclude>
                 <exclude>com.google.auto.**</exclude>
@@ -111,19 +111,19 @@
             </relocation>
             <relocation>
               <pattern>org</pattern>
-              <shadedPattern>shaded.cloud-nio.org</shadedPattern>
+              <shadedPattern>shaded.cloud_nio.org</shadedPattern>
             </relocation>
             <relocation>
               <pattern>io</pattern>
-              <shadedPattern>shaded.cloud-nio.io</shadedPattern>
+              <shadedPattern>shaded.cloud_nio.io</shadedPattern>
             </relocation>
             <relocation>
               <pattern>okio</pattern>
-              <shadedPattern>shaded.cloud-nio.okio</shadedPattern>
+              <shadedPattern>shaded.cloud_nio.okio</shadedPattern>
             </relocation>
             <relocation>
               <pattern>google</pattern>
-              <shadedPattern>shaded.cloud-nio.google</shadedPattern>
+              <shadedPattern>shaded.cloud_nio.google</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
Fixed the maven shade command so it produces a valid shaded package name.  It was producing shaded.cloud-nio.* which is not a valid java package and causes compilation errors when trying to import those packages.  This is problematic since the shaded packages are exposed in the API, so methods that exposed them were unusable by client code.

Shading now produces shading.cloud_nio.* which is valid